### PR TITLE
Vol2 section num fixes

### DIFF
--- a/input/pagecontent/rad-x1.md
+++ b/input/pagecontent/rad-x1.md
@@ -1,12 +1,12 @@
-### 2:3.X1.1 Scope
+### 2:4.X1.1 Scope
 
 This transaction is used to subscribe to receive events associated with a reporting session. A reporting session may include reporting on multiple reports, each of which has its own context.
 
-### 2:3.X1.2 Actors Roles
+### 2:4.X1.2 Actors Roles
 
 The roles in this transaction are defined in the following table and may be played by the actors shown here:
 
-**Table 2:3.X1.2-1: Actor Roles**
+**Table 2:4.X1.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -14,11 +14,11 @@ The roles in this transaction are defined in the following table and may be play
 | Manager | Receives and manages subscription requests | Hub |
 {: .grid}
 
-### 2:3.X1.3 Referenced Standards
+### 2:4.X1.3 Referenced Standards
 
 **FHIRcast**: [Subscribing to Events](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html)
 
-### 2:3.X1.4 Messages
+### 2:4.X1.4 Messages
 
 <div>
 {%include rad-x1-seq.svg%}
@@ -26,15 +26,15 @@ The roles in this transaction are defined in the following table and may be play
 
 <div style="clear: left"/>
 
-**Figure 2:3.X1.4-1: Interaction Diagram**
+**Figure 2:4.X1.4-1: Interaction Diagram**
 
-#### 2:3.X1.4.1 Subscription Request Message
+#### 2:4.X1.4.1 Subscription Request Message
 
 The Subscriber sends a reporting session subscription request to the Manager. The Subscriber shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Subscriber. 
 
-##### 2:3.X1.4.1.1 Trigger Events
+##### 2:4.X1.4.1.1 Trigger Events
 
 A Subscriber uses this transaction when:
 - It wants to start a new reporting session
@@ -42,13 +42,13 @@ A Subscriber uses this transaction when:
 - It wants to change the event filter for its existing subscription
 - It wants to renew its existing subscription
 
-##### 2:3.X1.4.1.2 Message Semantics
+##### 2:4.X1.4.1.2 Message Semantics
 
 This message is a [FHIRcast Subscription Request](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#subscription-request). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
 The request shall have the payload with the parameters in the following table:
 
-**Table 2:3.X1.4.1.2-1: Subscription Request Parameters**
+**Table 2:4.X1.4.1.2-1: Subscription Request Parameters**
 
 | Field                 | Optionality | Type     | Description |
 | ----------------------| ----------- | -------- | ------------|
@@ -63,7 +63,7 @@ The request shall have the payload with the parameters in the following table:
 
 > Note: Rows with '*' in the Optionality column have constraints different from baseline FHIRcast Subscription Request.
 
-##### 2:3.X1.4.1.3 Expected Actions
+##### 2:4.X1.4.1.3 Expected Actions
 
 The Manager shall receive and validate the message.
 
@@ -77,15 +77,15 @@ If the Subscriber already exist, then the Manager shall:
 - Update the list of events subscribed by the Subscriber
 - Update the expiry of the Subscriber's websocket connection
 
-#### 2:3.X1.4.2 Subscription Response Message
+#### 2:4.X1.4.2 Subscription Response Message
 
 The Manager sends a response message describing the request outcome to the Subscriber.
 
-##### 2:3.X1.4.2.1 Trigger Events
+##### 2:4.X1.4.2.1 Trigger Events
 
 The Manager receives a Subscribe to Reporting Session Request message.
 
-##### 2:3.X1.4.2.2 Message Semantics
+##### 2:4.X1.4.2.2 Message Semantics
 
 This message is a [FHIRcast Subscription Response](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#subscription-response). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -97,7 +97,7 @@ The Manager shall return `400` Bad Request error if:
 
 The Manager may return other applicable HTTP error status codes.
 
-##### 2:3.X1.4.2.3 Expected Actions
+##### 2:4.X1.4.2.3 Expected Actions
 
 If the HTTP response code is `202` Accepted, the Subscriber shall extract the websocket WSS URL from `hub.channel.endpoint`.
 
@@ -105,7 +105,7 @@ The Subscriber may use the `hub.channel.endpoint` in a subsequent Connect to Not
 
 If the HTTP response code is 4xx or 5xx, then the Subscriber may adjust the request and retry.
 
-### Security Considerations
+### 2:4.X1.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
@@ -113,7 +113,7 @@ The Subscriber which is a synchronizing application should authenticate and auth
 
 Local policy should consider what users and systems have permissions to subscribe to events and configure appropriately. More advanced implementations of the Manager might have logic to identify Subscribers that are requesting unnecessarily broad set of events.
 
-#### Security Audit Considerations
+#### 2:4.X1.5.1Security Audit Considerations
 
 Managers that support the ATNA Profile shall audit this transaction.
 

--- a/input/pagecontent/rad-x10.md
+++ b/input/pagecontent/rad-x10.md
@@ -1,10 +1,10 @@
-### 2:3.X10.1 Scope
+### 2:4.X10.1 Scope
 
 This transaction is used to distribute notification events to subscribers about synchronization errors detected by the Manager.
 
-### 2:3.X10.2 Actors Roles
+### 2:4.X10.2 Actors Roles
 
-**Table 2:3.X10.2-1: Actor Roles**
+**Table 2:4.X10.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,7 +12,7 @@ This transaction is used to distribute notification events to subscribers about 
 | Manager | Generates error event and notifies Subscribers | Hub |
 {: .grid}
 
-### 2:3.X10.3 Referenced Standards
+### 2:4.X10.3 Referenced Standards
 
 **FHIRcast**: [Event Notification Errors](https://build.fhir.org/ig/HL7/fhircast-docs/2-5-EventNotification.html#event-notification-errors)
 
@@ -20,7 +20,7 @@ This transaction is used to distribute notification events to subscribers about 
 
 **FHIRcast**: [Sync error Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-2-1-syncerror.html)
 
-### 2:3.X10.4 Messages
+### 2:4.X10.4 Messages
 
 <div>
 {%include rad-x10-seq.svg%}
@@ -28,15 +28,15 @@ This transaction is used to distribute notification events to subscribers about 
 
 <div style="clear: left"/>
 
-**Figure 2:3.X10.4-1: Interaction Diagram**
+**Figure 2:4.X10.4-1: Interaction Diagram**
 
-#### 2:3.X10.4.1 Error Notification Message
+#### 2:4.X10.4.1 Error Notification Message
 
 The Manager sends an error event to Subscribers indicating that it detected an error. Manager shall support sending such messages to more than one Subscribers.
 
 The Subscriber shall support handling such messages from more than one Manager. 
 
-##### 2:3.X10.4.1.1 Trigger Events
+##### 2:4.X10.4.1.1 Trigger Events
 
 A Manager uses this transaction when:
 - It receives a 4xx or 5xx error response from a Subscriber when executing the Send Context Event \[RAD-X9\](rad-x9.html) transaction.
@@ -44,7 +44,7 @@ A Manager uses this transaction when:
 - It initially responded with a `202` Accepted when received a context or content change, but later rejects the request associated with the session.
 - It detects a websocket connection issue with a Subscriber.
 
-##### 2:3.X10.4.1.2 Message Semantics
+##### 2:4.X10.4.1.2 Message Semantics
 
 This message is a [FHIRcast Event Notification Request](https://build.fhir.org/ig/HL7/fhircast-docs/2-5-EventNotification.html#event-notification-request) request. The Manager is the FHIRcast Hub. The Subscriber is the FHIRcast Subscriber.
 
@@ -59,30 +59,30 @@ The Manager shall set the `operationoutcome` `issue[0].details` as follow:
 
 If the `syncerror` event was triggered by the Manager initially accepting the context or content change request (i.e. responded with a `202` Accepted respond) but later rejecting the request, then the Manager shall send the `syncerror` event only to the original requesting Subscriber.
 
-##### 2:3.X10.4.1.3 Expected Actions
+##### 2:4.X10.4.1.3 Expected Actions
 
 The Subscriber will handle the error according to its business logic. For example, display an error message to the user, retry the original request, or close the context.
 
-#### 2:3.X10.4.2 Error Notification Response Message
+#### 2:4.X10.4.2 Error Notification Response Message
 
-##### 2:3.X10.4.2.1 Trigger Events
+##### 2:4.X10.4.2.1 Trigger Events
 
 The Subscriber processes the error notification received.
 
-##### 2:3.X10.4.2.2 Message Semantics
+##### 2:4.X10.4.2.2 Message Semantics
 
 The message is a [FHIRcast Event Notification Response](https://build.fhir.org/ig/HL7/fhircast-docs/2-5-EventNotification.html#event-notification-response) request. The Subscriber is a FHIRcast Subscriber. The Manager is a FHIRcast Hub.
 
 The Subscriber shall send a confirmation message back to the Manager using the established websocket connection.
 
-##### 2:3.X10.4.2.3 Expected Actions
+##### 2:4.X10.4.2.3 Expected Actions
 
 The Manager may resend the error notification if it does not receive a response from a Subscriber within a timeframe.
 
-### 2:3.X10.5 Security Considerations
+### 2:4.X10.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
-#### 2:3.X10.5.1 Security Audit Considerations
+#### 2:4.X10.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x11.md
+++ b/input/pagecontent/rad-x11.md
@@ -1,10 +1,10 @@
-### 2:3.X11.1 Scope
+### 2:4.X11.1 Scope
 
 This transaction is used to send error notifications when a Subscriber initially accepted an event and later failed to process it.
 
-### 2:3.X11.2 Actors Roles
+### 2:4.X11.2 Actors Roles
 
-**Table 2:3.X11.2-1: Actor Roles**
+**Table 2:4.X11.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,13 +12,13 @@ This transaction is used to send error notifications when a Subscriber initially
 | Manager | Accepts and processes notification | Hub |
 {: .grid}
 
-### 2:3.X11.3 Referenced Standards
+### 2:4.X11.3 Referenced Standards
 
 **FHIRcast**: [Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change)
 
 **FHIRcast**: [Sync error Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-2-1-syncerror.html)
 
-### 2:3.X11.4 Messages
+### 2:4.X11.4 Messages
 
 <div>
 {%include rad-x11-seq.svg%}
@@ -26,19 +26,19 @@ This transaction is used to send error notifications when a Subscriber initially
 
 <div style="clear: left"/>
 
-**Figure 2:3.X11.4-1: Interaction Diagram**
+**Figure 2:4.X11.4-1: Interaction Diagram**
 
-#### 2:3.X11.4.1 Notify Error Message
+#### 2:4.X11.4.1 Notify Error Message
 
 The Subscriber sends an error event to the Manager indicating that it failed to process a notification. The Subscriber shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Subscriber. 
 
-##### 2:3.X11.4.1.1 Trigger Events
+##### 2:4.X11.4.1.1 Trigger Events
 
 The Subscriber failed to successfully process an context event that the Subscriber initially accepted and responded with `202` Accepted.
 
-##### 2:3.X11.4.1.2 Message Semantics
+##### 2:4.X11.4.1.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) request. The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -50,17 +50,17 @@ If the Sender is retrying this context change request due to not receiving a res
 
 If the Sender retries the request due to an error response from the Manager, then the Sender shall assign a new `event.id` to indicate that it is a new request.
 
-##### 2:3.X11.4.1.3 Expected Actions
+##### 2:4.X11.4.1.3 Expected Actions
 
 The Manager shall receive and validate the request. See 2:3.X11.4.2.2 for error conditions.
 
-#### 2:3.X11.4.2 Notify Error Response Message
+#### 2:4.X11.4.2 Notify Error Response Message
 
-##### 2:3.X11.4.2.1 Trigger Events
+##### 2:4.X11.4.2.1 Trigger Events
 
 The Manager finished processing the Notify Error request.
 
-##### 2:3.X11.4.2.2 Message Semantics
+##### 2:4.X11.4.2.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) response. The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -72,14 +72,14 @@ The Manager shall return `400` Bad Request error:
 
 The Manager may return other applicable HTTP error status codes.
 
-##### 2:3.X11.4.2.3 Expected Actions
+##### 2:4.X11.4.2.3 Expected Actions
 
 If the response is an error, then the Subscriber may consider retrying the request.
 
-### 2:3.X11.5 Security Considerations
+### 2:4.X11.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
-#### 2:3.X11.5.1 Security Audit Considerations
+#### 2:4.X11.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x2.md
+++ b/input/pagecontent/rad-x2.md
@@ -1,10 +1,10 @@
-### 2:3.X2.1 Scope
+### 2:4.X2.1 Scope
 
 This transaction is used to connect to a notification channel to receive synchronization events.
 
-### 2:3.X2.2 Actors Roles
+### 2:4.X2.2 Actors Roles
 
-**Table 2:3.X2.2-1: Actor Roles**
+**Table 2:4.X2.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,13 +12,13 @@ This transaction is used to connect to a notification channel to receive synchro
 | Manager | Establish a websocket notification channel and manage connection | Hub |
 {: .grid}
 
-### 2:3.X2.3 Referenced Standards
+### 2:4.X2.3 Referenced Standards
 
 **FHIRcast**: [Subscribing to Events](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html)
 
 **Websocket**: [IETF RFC 6455](https://www.rfc-editor.org/rfc/rfc6455)
 
-### 2:3.X2.4 Messages
+### 2:4.X2.4 Messages
 
 <div>
 {%include rad-x2-seq.svg%}
@@ -26,24 +26,24 @@ This transaction is used to connect to a notification channel to receive synchro
 
 <div style="clear: left"/>
 
-**Figure 2:3.X2.4-1: Interaction Diagram**
+**Figure 2:4.X2.4-1: Interaction Diagram**
 
-#### 2:3.X2.4.1 Subscription Request Message
+#### 2:4.X2.4.1 Subscription Request Message
 The Subscriber sends a websocket connection request to the Manager. The Subscriber shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Subscriber. 
 
-##### 2:3.X2.4.1.1 Trigger Events
+##### 2:4.X2.4.1.1 Trigger Events
 
 The Subscriber receives a successful Subscribe to Reporting Session [RAD-X1] response.
 
-##### 2:3.X2.4.1.2 Message Semantics
+##### 2:4.X2.4.1.2 Message Semantics
 
 This message is a websocket connection request. The Subscriber is the Client. The Manager is the Server.
 
 The Subscriber shall send a websocket request to the `hub.channel.endpoint` websocket WSS URL received from the successful Subscribe to Reporting Session [RAD-X1] response. 
 
-##### 2:3.X2.4.1.3 Expected Actions
+##### 2:4.X2.4.1.3 Expected Actions
 
 The Manager shall process the request.
 
@@ -53,13 +53,13 @@ The Manager shall keep the websocket connection open for use as a notification c
 
 The Manager shall use the opened websocket connection when sending subsequent events to the Subscriber.
 
-#### 2:3.X2.4.2 Subscription Response Message
+#### 2:4.X2.4.2 Subscription Response Message
 
-##### 2:3.X2.4.2.1 Trigger Events
+##### 2:4.X2.4.2.1 Trigger Events
 
 The Manager processes the websocket connection request.
 
-##### 2:3.X2.4.2.2 Message Semantics
+##### 2:4.X2.4.2.2 Message Semantics
 
 This is a [FHIRcast Subscription Confirmation](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#subscription-confirmation). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -67,10 +67,10 @@ This is a [FHIRcast Subscription Confirmation](https://build.fhir.org/ig/HL7/fhi
 
 The Subscriber will find the duration of the websocket lease in the `hub.lease_seconds` attribute of this message. When the lease expires, the Manager may drop the connection. It is the responsibility of the Subscriber to renew the subscription as needed before it expires using Subscribe to Reporting Session [RAD-X1].
 
-### 2:3.X2.5 Security Considerations
+### 2:4.X2.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
-#### 2:3.X2.5.1 Security Audit Considerations
+#### 2:4.X2.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x3.md
+++ b/input/pagecontent/rad-x3.md
@@ -1,10 +1,10 @@
-### 2:3.X3.1 Scope
+### 2:4.X3.1 Scope
 
 This transaction is used to open a report context. Report contexts are opened within an existing reporting session.
 
-### 2:3.X3.2 Actors Roles
+### 2:4.X3.2 Actors Roles
 
-**Table 2:3.X3.2-1: Actor Roles**
+**Table 2:4.X3.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,13 +12,13 @@ This transaction is used to open a report context. Report contexts are opened wi
 | Manager | Manages opened context | Hub |
 {: .grid}
 
-### 2:3.X3.3 Referenced Standards
+### 2:4.X3.3 Referenced Standards
 
 **FHIRcast**: [Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change)
 
 **FHIRcast**: [DiagnosticReport open Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-6-1-diagnosticreport-open.html)
 
-### 2:3.X3.4 Messages
+### 2:4.X3.4 Messages
 
 <div>
 {%include rad-x3-seq.svg%}
@@ -26,28 +26,28 @@ This transaction is used to open a report context. Report contexts are opened wi
 
 <div style="clear: left"/>
 
-**Figure 2:3.X3.4-1: Interaction Diagram**
+**Figure 2:4.X3.4-1: Interaction Diagram**
 
-#### 2:3.X3.4.1 Open Report Context Request Message
+#### 2:4.X3.4.1 Open Report Context Request Message
 The Sender sends an event to the Manager to open a report context. The Sender shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Sender. 
 
-##### 2:3.X3.4.1.1 Trigger Events
+##### 2:4.X3.4.1.1 Trigger Events
 
 A Sender uses this transaction when:
 - It determines that work should begin on a new report, and opens a new context to synchronize that work with other Subscribers.
 - It determines to resume a previously opened report that has not yet complete, and re-opens the same context to synchronize that work with other Subscribers.
 
-##### 2:3.X3.4.1.2 Message Semantics
+##### 2:4.X3.4.1.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) request. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
 The `event.context` shall conform to [DiagnosticReport open Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-6-1-diagnosticreport-open.html).
 
-In addition, the contexts in the `event.context` shall conform to the Table 2:3.X3.4.1.2-1.
+In addition, the contexts in the `event.context` shall conform to the Table 2:4.X3.4.1.2-1.
 
-**Table 2:3.X3.4.1.2-1: Context Requirements**
+**Table 2:4.X3.4.1.2-1: Context Requirements**
 
 | Key | Optionality | Context Requirements |
 |-----|-------------|----------------------|
@@ -63,21 +63,21 @@ If the Sender is retrying this context change request due to not receiving a res
 
 If the Sender retries the request due to an error response from the Manager, then the Sender shall assign a new `event.id` to indicate that it is a new request.
 
-##### 2:3.X3.4.1.3 Expected Actions
+##### 2:4.X3.4.1.3 Expected Actions
 
-The Manager shall receive and validate the request. See 2:3.X3.4.2.2 for error conditions.
+The Manager shall receive and validate the request. See Section 2:4.X3.4.2.2 for error conditions.
 
 Per FHIRcast, this `report` context will become the current context in this reporting session.
 
 If the `report`, `patient` and `study` contexts in the request match an existing report context which has not been closed, then the Manager shall update that report context and set it to be the current context.
 
-#### 2:3.X3.4.2 Open Report Context Response Message
+#### 2:4.X3.4.2 Open Report Context Response Message
 
-##### 2:3.X3.4.2.1 Trigger Events
+##### 2:4.X3.4.2.1 Trigger Events
 
 The Manager finishes processing the Open Report Context request.
 
-##### 2:3.X3.4.2.2 Message Semantics
+##### 2:4.X3.4.2.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) response. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -89,16 +89,16 @@ The Manager shall return `400` Bad Request error if:
 
 The Manager may return other applicable HTTP error status codes.
 
-##### 2:3.X3.4.2.3 Expected Actions
+##### 2:4.X3.4.2.3 Expected Actions
 
 If the response is an error, then the Sender may consider retrying the request.
 
-### 2:3.X3.5 Security Considerations
+### 2:4.X3.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
 Local policy should consider what users and systems have permissions to open a report context and configure appropriately. 
 
-#### 2:3.X3.5.1 Security Audit Considerations
+#### 2:4.X3.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x4.md
+++ b/input/pagecontent/rad-x4.md
@@ -1,12 +1,12 @@
-### 2:3.X4.1 Scope
+### 2:4.X4.1 Scope
 
 This transaction is used to terminate a report context. All synchronizing applications are expected to close their local copy of this context.
 
 > Note: This closes the report context used for synchronization / sharing. The report instance being worked on may or may not be complete.
 
-### 2:3.X4.2 Actors Roles
+### 2:4.X4.2 Actors Roles
 
-**Table 2:3.X4.2-1: Actor Roles**
+**Table 2:4.X4.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -14,7 +14,7 @@ This transaction is used to terminate a report context. All synchronizing applic
 | Manager | Closes report context | Hub |
 {: .grid}
 
-### 2:3.X4.3 Referenced Standards
+### 2:4.X4.3 Referenced Standards
 
 **FHIRcast**: [Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change)
 
@@ -28,18 +28,18 @@ This transaction is used to terminate a report context. All synchronizing applic
 
 <div style="clear: left"/>
 
-**Figure 2:3.X4.4-1: Interaction Diagram**
+**Figure 2:4.X4.4-1: Interaction Diagram**
 
-#### 2:3.X4.4.1 Close Report Context Request Message
+#### 2:4.X4.4.1 Close Report Context Request Message
 The Sender sends an event to the Manager to terminate an existing report context. The Sender shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Sender. 
 
-##### 2:3.X4.4.1.1 Trigger Events
+##### 2:4.X4.4.1.1 Trigger Events
 
 The Sender determines no further synchronization required for this report context. The report instance being worked on may or may not be complete.
 
-##### 2:3.X4.4.1.2 Message Semantics
+##### 2:4.X4.4.1.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) request. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -49,7 +49,7 @@ If the Sender is retrying this context change request due to not receiving a res
 
 If the Sender retries the request due to an error response from the Manager, then the Sender shall assign a new `event.id` to indicate that it is a new request.
 
-##### 2:3.X4.4.1.3 Expected Actions
+##### 2:4.X4.4.1.3 Expected Actions
 
 The Manager shall receive and validate the request. See 2:3.X4.4.2.2 for error conditions.
 
@@ -57,13 +57,13 @@ If the Manager accepts the request, then
 - Per FHIRcast [Section 2.9.2 Get Current Context Response](https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html#get-current-context-response), the Manager will set the `current context` to the context that was most recently opened by a `[FHIR resource]-open` event and has not been closed by a corresponding `[FHIR resource]-close` event. If there is no such context, then the Manager will set the `current context` to *empty*.
 - Per FHIRcast, the Manager will remove from the memory the `report` context of the received `DiagnosticReport-close` event, as well as all associated context and content.
 
-#### 2:3.X4.4.2 Close Report Context Response Message
+#### 2:4.X4.4.2 Close Report Context Response Message
 
-##### 2:3.X4.4.2.1 Trigger Events
+##### 2:4.X4.4.2.1 Trigger Events
 
 The Manager finishes processing the Close Report Context request.
 
-##### 2:3.X4.4.2.2 Message Semantics
+##### 2:4.X4.4.2.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) response. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -75,16 +75,16 @@ The Manager shall return `400` Bad Request error if:
 
 The Manager may return other applicable HTTP error status codes.
 
-##### 2:3.X4.4.2.3 Expected Actions
+##### 2:4.X4.4.2.3 Expected Actions
 
 If the response is an error, then the Sender may consider retrying the request.
 
-### 2:3.X4.5 Security Considerations
+### 2:4.X4.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
 Local policy should consider what users and systems have permissions to close a report context and configure appropriately. 
 
-#### 2:3.X4.5.1 Security Audit Considerations
+#### 2:4.X4.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x5.md
+++ b/input/pagecontent/rad-x5.md
@@ -1,10 +1,10 @@
-### 2:3.X5.1 Scope
+### 2:4.X5.1 Scope
 
 This transaction is used to add, change or remove contents in a report context.
 
-### 2:3.X5.2 Actors Roles
+### 2:4.X5.2 Actors Roles
 
-**Table 2:3.X5.2-1: Actor Roles**
+**Table 2:4.X5.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,13 +12,13 @@ This transaction is used to add, change or remove contents in a report context.
 | Manager | Updates the report context | Hub |
 {: .grid}
 
-### 2:3.X5.3 Referenced Standards
+### 2:4.X5.3 Referenced Standards
 
 **FHIRcast**: [Content Sharing](https://build.fhir.org/ig/HL7/fhircast-docs/2-10-ContentSharing.html)
 
 **FHIRcast**: [DiagnosticReport update Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-6-3-diagnosticreport-update.html)
 
-### 2:3.X5.4 Messages
+### 2:4.X5.4 Messages
 
 <div>
 {%include rad-x5-seq.svg%}
@@ -26,18 +26,18 @@ This transaction is used to add, change or remove contents in a report context.
 
 <div style="clear: left"/>
 
-**Figure 2:3.X5.4-1: Interaction Diagram**
+**Figure 2:4.X5.4-1: Interaction Diagram**
 
-#### 2:3.X5.4.1 Update Report Content Request Message
+#### 2:4.X5.4.1 Update Report Content Request Message
 The Sender sends an event to the Manager to add, change or remove content relevant to an existing report context. The Sender shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Sender. 
 
-##### 2:3.X5.4.1.1 Trigger Events
+##### 2:4.X5.4.1.1 Trigger Events
 
 The Sender determines new content should be added, existing content should be changed, or existing content should be removed from a report context.
 
-##### 2:3.X5.4.1.2 Message Semantics
+##### 2:4.X5.4.1.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) request. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -53,18 +53,18 @@ If the Sender is retrying this context change request due to not receiving a res
 
 If the Sender retries the request due to an error response from the Manager, then the Sender shall assign a new `event.id` to indicate that it is a new request.
 
-##### 2:3.X5.4.1.3 Expected Actions
+##### 2:4.X5.4.1.3 Expected Actions
 
-The Manager shall receive and validate the request. See 2:3.X5.4.2.2 for error conditions.
+The Manager shall receive and validate the request. See Section 2:4.X5.4.2.2 for error conditions.
 
 Per FHIRcast,
 - If the `context.versionId` in the request does not match the version ID of the `report` anchor context, then the Manager will not apply any updates.
 - The Manager will apply the set of updates in the request *atomically*. i.e. The Manager will apply all updates or none of the updates.
 - If the Manager successfully applies all updates in the request, it will assign a new version ID to the `report` anchor context.
 
-#### 2:3.X5.4.2 Update Report Content Response Message
+#### 2:4.X5.4.2 Update Report Content Response Message
 
-##### 2:3.X5.4.2.1 Trigger Events
+##### 2:4.X5.4.2.1 Trigger Events
 
 The Manager finishes processing the Update Report Content request.
 
@@ -82,16 +82,16 @@ If the Manager rejected the Update Report Content request, then the Manager shal
 
 The Manager may return other applicable HTTP error status codes.
 
-##### 2:3.X5.4.2.3 Expected Actions
+##### 2:4.X5.4.2.3 Expected Actions
 
 If the response is an error, then the Sender may consider retrying the request.
 
-### 2:3.X5.5 Security Considerations
+### 2:4.X5.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
 Local policy should consider what users and systems have permissions to update report content and configure appropriately. 
 
-#### 2:3.X5.5.1 Security Audit Considerations
+#### 2:4.X5.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x6.md
+++ b/input/pagecontent/rad-x6.md
@@ -1,10 +1,10 @@
-### 2:3.X6.1 Scope
+### 2:4.X6.1 Scope
 
 This transaction is used to identify specific report contents to other subscribers for potential synchronization.
 
-### 2:3.X6.2 Actors Roles
+### 2:4.X6.2 Actors Roles
 
-**Table 2:3.X6.2-1: Actor Roles**
+**Table 2:4.X6.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,13 +12,13 @@ This transaction is used to identify specific report contents to other subscribe
 | Manager | Manages the selection state of contents | Hub |
 {: .grid}
 
-### 2:3.X6.3 Referenced Standards
+### 2:4.X6.3 Referenced Standards
 
 **FHIRcast**: [Content Sharing](https://build.fhir.org/ig/HL7/fhircast-docs/2-10-ContentSharing.html)
 
 **FHIRcast**: [DiagnosticReport select Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-6-4-diagnosticreport-select.html)
 
-### 2:3.X6.4 Messages
+### 2:4.X6.4 Messages
 
 <div>
 {%include rad-x6-seq.svg%}
@@ -26,14 +26,14 @@ This transaction is used to identify specific report contents to other subscribe
 
 <div style="clear: left"/>
 
-**Figure 2:3.X6.4-1: Interaction Diagram**
+**Figure 2:4.X6.4-1: Interaction Diagram**
 
-#### 2:3.X6.4.1 Select Report Content Request Message
+#### 2:4.X6.4.1 Select Report Content Request Message
 The Sender sends an event to the Manager to indicate some report contents are selected. The Sender shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Sender. 
 
-##### 2:3.X6.4.1.1 Trigger Events
+##### 2:4.X6.4.1.1 Trigger Events
 
 The Sender determines the selection state of some report contents should be synchronized with other Subscribers. Selections may have occurred automatically or manually by a user.
 
@@ -41,7 +41,7 @@ The Sender determines that the selected content are no longer required and reset
 
 > Note: Prior selected content are automatically reset by the selection of new content. Reset is used when the current selected content should be unselected without selecting new contents. See [DiagnosticReport select Event Workflow](https://build.fhir.org/ig/HL7/fhircast-docs/3-6-4-diagnosticreport-select.html#workflow) for details.
 
-##### 2:3.X6.4.1.2 Message Semantics
+##### 2:4.X6.4.1.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) request. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -57,9 +57,9 @@ If the Sender is retrying this context change request due to not receiving a res
 
 If the Sender retries the request due to an error response from the Manager, then the Sender shall assign a new `event.id` to indicate that it is a new request.
 
-##### 2:3.X6.4.1.3 Expected Actions
+##### 2:4.X6.4.1.3 Expected Actions
 
-The Manager shall receive and validate the request. See 2:3.X6.4.2.2 for error conditions.
+The Manager shall receive and validate the request. See Section 2:4.X6.4.2.2 for error conditions.
 
 Per FHIRcast, the Manager will keep track of the selection states of all contents. In particular:
 - All previously selected contents will be unselected
@@ -69,13 +69,13 @@ The Manager shall ignore any selected resources in the request that are not know
 
 > Note: The Manager should continue to process the request and should not return an error due to unknown selected resources.
 
-#### 2:3.X6.4.2 Select Report Content Response Message
+#### 2:4.X6.4.2 Select Report Content Response Message
 
-##### 2:3.X6.4.2.1 Trigger Events
+##### 2:4.X6.4.2.1 Trigger Events
 
 The Manager finishes processing the Select Report Content request.
 
-##### 2:3.X6.4.2.2 Message Semantics
+##### 2:4.X6.4.2.2 Message Semantics
 
 This message is a [FHIRcast Request Context Change](https://build.fhir.org/ig/HL7/fhircast-docs/2-6-RequestContextChange.html#request-context-change-body) response. The Sender is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -89,16 +89,16 @@ The Manager shall return `400` Bad Request error:
 
 The Manager may return other applicable HTTP error status codes.
 
-##### 2:3.X6.4.2.3 Expected Actions
+##### 2:4.X6.4.2.3 Expected Actions
 
 If the response is an error, then the Sender may consider retrying the request.
 
-### 2:3.X6.5 Security Considerations
+### 2:4.X6.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
 Local policy should consider what users and systems have permissions to select report content and configure appropriately. 
 
-#### 2:3.X6.5.1 Security Audit Considerations
+#### 2:4.X6.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.

--- a/input/pagecontent/rad-x7.md
+++ b/input/pagecontent/rad-x7.md
@@ -1,12 +1,12 @@
-### 2:3.X7.1 Scope
+### 2:4.X7.1 Scope
 
 This transaction is used to unsubscribe from a FHIRcast session.
 
-### 2:3.X7.2 Actors Roles
+### 2:4.X7.2 Actors Roles
 
 The roles in this transaction are defined in the following table and may be played by the actors shown here:
 
-**Table 2:3.X7.2-1: Actor Roles**
+**Table 2:4.X7.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -26,39 +26,39 @@ The roles in this transaction are defined in the following table and may be play
 
 <div style="clear: left"/>
 
-**Figure 2:3.X7.4-1: Interaction Diagram**
+**Figure 2:4.X7.4-1: Interaction Diagram**
 
-#### 2:3.X7.4.1 Unsubscribe Session Request Message
+#### 2:3.47.4.1 Unsubscribe Session Request Message
 
 The Subscriber sends a unsubscribe request to the Manager. The Subscriber shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Subscriber. 
 
-##### 2:3.X7.4.1.1 Trigger Events
+##### 2:4.x7.4.1.1 Trigger Events
 
 The Subscriber no longer wants to receive event notification on a given session from Manager.
 
-##### 2:3.X7.4.1.2 Message Semantics
+##### 2:4.X7.4.1.2 Message Semantics
 
 This message is a [FHIRcast Unsubscription Request](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#unsubscribe). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
-##### 2:3.X7.4.1.3 Expected Actions
+##### 2:4.X7.4.1.3 Expected Actions
 
-The Manager shall receive and validate the message. See 2:3.X7.4.2.2 for error conditions.
+The Manager shall receive and validate the message. See Section 2:4.X7.4.2.2 for error conditions.
 
 Per FHIRcast, the Manager will remove the Subscriber from all event subscriptions in this session.
 
 The Manager shall terminate the websocket connection and delete the websocket identifier. The Manager shall not reuse the websocket identifier for other future subscriptions.
 
-#### 2:3.X7.4.2 Unsubscribe Session Response Message
+#### 2:4.X7.4.2 Unsubscribe Session Response Message
 
 The Manager sends a response message describing the message outcome to the Subscriber.
 
-##### 2:3.X7.4.2.1 Trigger Events
+##### 2:4.X7.4.2.1 Trigger Events
 
 The Manager receives a Unsubscribe Session Request message.
 
-##### 2:3.X7.4.2.2 Message Semantics
+##### 2:4.X7.4.2.2 Message Semantics
 
 This message is a [FHIRcast Unsubscription Response](https://build.fhir.org/ig/HL7/fhircast-docs/2-4-Subscribing.html#unsubscribe). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
@@ -74,17 +74,17 @@ The Manager may return other applicable HTTP error status codes.
 
 The HTTP body of the response shall consist of a JSON object containing an element name `hub.channel.endpoint` and a value for the websocket URL that is associated to the Subscriber.
 
-##### 2:3.X7.4.2.3 Expected Actions
+##### 2:4.X7.4.2.3 Expected Actions
 
 The Subscriber may check the returned `hub.channel.endpoint` in the response and verify that it matches the websocket URL it requested.
 
 If the HTTP response code is 4xx or 5xx, then the Subscriber may adjust the request and retry.
 
-### Security Considerations
+### 2:4.X7.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
-#### Security Audit Considerations
+#### 2:4.X7.5.1 Security Audit Considerations
 
 Managers that support the ATNA Profile shall audit this transaction.
 

--- a/input/pagecontent/rad-x8.md
+++ b/input/pagecontent/rad-x8.md
@@ -1,10 +1,10 @@
-### 2:3.X8.1 Scope
+### 2:4.X8.1 Scope
 
 This transaction is used to retrieve the current context for a given session and all associated contents in that context.
 
-### 2:3.X8.2 Actors Roles
+### 2:4.X8.2 Actors Roles
 
-**Table 2:3.X8.2-1: Actor Roles**
+**Table 2:4.X8.2-1: Actor Roles**
 
 | Role | Description | Actor(s) |
 |------|-------------|----------|
@@ -12,11 +12,11 @@ This transaction is used to retrieve the current context for a given session and
 | Manager | Returns current context and contents | Hub |
 {: .grid}
 
-### 2:3.X8.3 Referenced Standards
+### 2:4.X8.3 Referenced Standards
 
 **FHIRcast**: [Get Current Context](https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html)
 
-### 2:3.X8.4 Messages
+### 2:4.X8.4 Messages
 
 <div>
 {%include rad-x8-seq.svg%}
@@ -24,27 +24,27 @@ This transaction is used to retrieve the current context for a given session and
 
 <div style="clear: left"/>
 
-**Figure 2:3.X8.4-1: Interaction Diagram**
+**Figure 2:4.X8.4-1: Interaction Diagram**
 
-#### 2:3.X8.4.1 Get Current Context Request Message
+#### 2:4.X8.4.1 Get Current Context Request Message
 The Subscriber requests the current context and its contents for an identified session. The Subscriber shall support sending such messages to more than one Manager.
 
 The Manager shall support handling such messages from more than one Subscriber. 
 
-##### 2:3.X8.4.1.1 Trigger Events
+##### 2:4.X8.4.1.1 Trigger Events
 
 The Subscriber uses this transaction when:
 - It successfully subscribes to a session and wants to have the current context
 - It determines that it has missed some events for the current context based on receiving an context event with an unexpected version
 - It receives a `[FHIR resource]-close` event and wants to synchronize with the new current context, if any
 
-##### 2:3.X8.4.1.2 Message Semantics
+##### 2:4.X8.4.1.2 Message Semantics
 
 This message is a [Get Current Context Request](https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html#get-current-context-request). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
 The topic in the request URL will identifies the session for which the current context and contents are being requested.
 
-##### 2:3.X8.4.1.3 Expected Actions
+##### 2:4.X8.4.1.3 Expected Actions
 
 The Manager shall validate if the `topic` specified in the request URL is a valid session.
 
@@ -52,31 +52,31 @@ The Manager shall retrieve the current context and all associated contents corre
 
 > Note: The current context is the anchor context with all associated contexts. For example, in a `DiagnosticReport-open` event, the current context includes `report`, `patient` and `study` contexts, in which `report` is the anchor context.
 
-#### 2:3.X8.4.2 Get Current Context Response Message
+#### 2:4.X8.4.2 Get Current Context Response Message
 
 The Manager returns the current context and all associated contents.
 
-##### 2:3.X8.4.2.1 Trigger Events
+##### 2:4.X8.4.2.1 Trigger Events
 
 The Manager receives the Get Current Context request.
 
-##### 2:3.X8.4.2.2 Message Semantics
+##### 2:4.X8.4.2.2 Message Semantics
 
 This message is a [Get Current Context Response](https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html#get-current-context-response). The Subscriber is the FHIRcast Subscriber. The Manager is the FHIRcast Hub.
 
 The Manager shall include the `content` key in the response. See [Content Sharing Support](https://build.fhir.org/ig/HL7/fhircast-docs/2-9-GetCurrentContext.html#content-sharing-support) for details.
 
-##### 2:3.X8.4.2.3 Expected Actions
+##### 2:4.X8.4.2.3 Expected Actions
 
 The Subscriber shall process the context as if it had received the `[FHIR resource]-open` event with the same context.
 
 The Subscriber shall replace the set of known contents associated with the context with the resources in the `content` bundle according to its business logic. 
 
-### 2:3.X8.5 Security Considerations
+### 2:4.X8.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
-#### 2:3.X8.5.1 Security Audit Considerations
+#### 2:4.X8.5.1 Security Audit Considerations
 
 Managers that support the ATNA Profile shall audit this transaction.
 

--- a/input/pagecontent/rad-x9.md
+++ b/input/pagecontent/rad-x9.md
@@ -1,10 +1,10 @@
-### 2:3.X9.1 Scope
+### 2:4.X9.1 Scope
 
 This transaction is used to distribute notification events to subscribers. This allows a Subscriber to synchronize to changes in the reporting session initiated by other Subscribers.
 
-### 2:3.X9.2 Actors Roles
+### 2:4.X9.2 Actors Roles
 
-**Table 2:3.X9.2-1: Actor Roles**
+**Table 2:4.X9.2-1: Actor Roles**
 
 | Role | Description | Actor(s)                         |
 |------|-------------|----------------------------------|
@@ -12,7 +12,7 @@ This transaction is used to distribute notification events to subscribers. This 
 | Subscriber | Receives notification events | Image Display<br>Report Creator<br>Worklist Client<br>Evidence Creator<br>Watcher |
 {: .grid}
 
-### 2:3.X9.3 Referenced Standards
+### 2:4.X9.3 Referenced Standards
 
 **FHIRcast**: [Event Notification](https://build.fhir.org/ig/HL7/fhircast-docs/2-5-EventNotification.html)
 
@@ -20,7 +20,7 @@ This transaction is used to distribute notification events to subscribers. This 
 
 **FHIRcast**: [Sync error Event](https://build.fhir.org/ig/HL7/fhircast-docs/3-2-1-syncerror.html)
 
-### 2:3.X9.4 Messages
+### 2:4.X9.4 Messages
 
 <div>
 {%include rad-x9-seq.svg%}
@@ -28,24 +28,24 @@ This transaction is used to distribute notification events to subscribers. This 
 
 <div style="clear: left"/>
 
-**Figure 2:3.X9.4-1: Interaction Diagram**
+**Figure 2:4.X9.4-1: Interaction Diagram**
 
-#### 2:3.X9.4.1 Notification Message
+#### 2:4.X9.4.1 Notification Message
 The Manager sends the received notification events to Subscribers that listed this event type in their subscription. The Manager shall support sending such messages to more than one Subscriber.
 
 The Subscriber shall support handling such messages from more than one Manager. 
 
-##### 2:3.X9.4.1.1 Trigger Events
+##### 2:4.X9.4.1.1 Trigger Events
 
 The Manager accepts a notification event request and this Subscriber has listed this event type in its subscription.
 
-##### 2:3.X9.4.1.2 Message Semantics
+##### 2:4.X9.4.1.2 Message Semantics
 
 This message is a [FHIRcast Event Notification Request](https://build.fhir.org/ig/HL7/fhircast-docs/2-5-EventNotification.html#event-notification-request) request. The Manager is the FHIRcast Hub. The Subscriber is the FHIRcast Subscriber.
 
 The Manager shall support the additional requirements regarding `version id` defined in FHIRcast [content sharing](https://build.fhir.org/ig/HL7/fhircast-docs/2-10-ContentSharing.html).
 
-##### 2:3.X9.4.1.3 Expected Actions
+##### 2:4.X9.4.1.3 Expected Actions
 
 The Subscriber may validate the received event according to its business logic. If the Subscriber rejects the event, then it shall notify the Manager about the error.
 
@@ -55,13 +55,13 @@ The Subscriber shall support [content sharing](https://build.fhir.org/ig/HL7/fhi
 
 > Note: The Subscriber may handle the event synchronously. The Subscriber may also handle the event asynchronously by accepting the event initially (i.e., returning `202` Accepted) and processing it later.
 
-##### 2:3.X9.4.1.3.1 Handling open events
+##### 2:4.X9.4.1.3.1 Handling open events
 
 Upon receiving a `[FHIR resource]-open` event, the Subscriber will *open* the corresponding `event.context` according to its business logic. The semantics of the open event may be further described in the corresponding 'open request' transaction.
 
 > Note: `[FHIR resource]-open` events occur when a context is initially created and when it is re-opened. Subscriber event handling may differ for these two cases.
 
-##### 2:3.X9.4.1.3.2 Handling update events
+##### 2:4.X9.4.1.3.2 Handling update events
 
 Upon receiving a `[FHIR resource]-update` event, the Subscriber:
 - Will validate if the `context.priorVersionId` in the event matches the current version ID in the local context.
@@ -70,25 +70,25 @@ Upon receiving a `[FHIR resource]-update` event, the Subscriber:
 - Shall update the current version ID in the local context to match the `context.versionId` from the event, even if its business logic requires no specific processing.
 - For contents of interest that are not inline in the `[FHIR resource]-update` event, the Subscriber will need to retrieve the content based on the `entry.fullurl`.
 
-##### 2:3.X9.4.1.3.3 Handling select events
+##### 2:4.X9.4.1.3.3 Handling select events
 
 Upon receiving a `[FHIR resource]-select` event, the Subscriber:
-- Will validate if the `context.priorVersionId` in the event matches the current version ID in the local context as described in Section 2:3.X9.4.1.3.2.
+- Will validate if the `context.priorVersionId` in the event matches the current version ID in the local context as described in Section 2:4.X9.4.1.3.2.
 - Shall track which of the resources in the local context are currently selected and be capable of using applicable selected resources in subsequent user commands according to its business logic.
 - Shall update the current version ID in the local context to match the `context.versionId` from the event, even if its business logic requires no specific processing.
 - Shall ignore any resources selected in the event that are not known to the Subscriber
 
-##### 2:3.X9.4.1.3.4 Handling close events
+##### 2:4.X9.4.1.3.4 Handling close events
 
 Upon receiving a `[FHIR resource]-close` event, the Subscriber shall close the referenced context and all associated contents. This typically involves deleting it from its local context.
 
-#### 2:3.X9.4.2 Notification Response Message
+#### 2:4.X9.4.2 Notification Response Message
 
-##### 2:3.X9.4.2.1 Trigger Events
+##### 2:4.X9.4.2.1 Trigger Events
 
 The Subscriber processes the Notification Message.
 
-##### 2:3.X9.4.2.2 Message Semantics
+##### 2:4.X9.4.2.2 Message Semantics
 
 The message is a [FHIRcast Event Notification Response](https://build.fhir.org/ig/HL7/fhircast-docs/2-5-EventNotification.html#event-notification-response) request. The Subscriber is a FHIRcast Subscriber. The Manager is a FHIRcast Hub.
 
@@ -101,7 +101,7 @@ The `status` shall be one of the following:
 
 > Note: If the Subscriber returned with `status` `202` Accepted and later failed to process the event, then the Subscriber shall send a `syncerror` event following [Notify Error](rad-x11.html).
 
-##### 2:3.X9.4.2.3 Expected Actions
+##### 2:4.X9.4.2.3 Expected Actions
 
 If the Manager receives an error confirmation message (i.e., `status` `4xx` or `5xx`) from at least one of the Subscribers, then the Manager shall send a `syncerror` event following [Notify Error](rad-x11.html) to all subscribers that subscribed to the `syncerror` event.
 
@@ -109,10 +109,10 @@ The Manager shall not change the current context in the session even if it recei
 
 > Note: The Manager sets the current context as a result of processing a `[FHIR resource]-open` event. Whether or not one or more of the Subscribers failed to apply the context change does not affect the context managed by the Manager.
 
-### 2:3.X9.5 Security Considerations
+### 2:4.X9.5 Security Considerations
 
 See [IRA Security Considerations](volume-1.html#1xx5-ira-security-considerations).
 
-#### 2:3.X9.5.1 Security Audit Considerations
+#### 2:4.X9.5.1 Security Audit Considerations
 
 This transaction is not associated with an ATNA Trigger Event.


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 

Please make sure that the pull request is limited to one Issue and keep it as small as possible. You can open multiple pull request instead of opening a huge one.
-->


## 📑 Description
In the RAD TF, all Vol 2 transactions come under section 4, e.g. RAD-1 is in Section 2.4.  This PR fixes all section numbers, figure numbers, and table numbers in IRA Vol 2 transaction text.

